### PR TITLE
windows,ci: Fix vcpkg bootstrap confirmation

### DIFF
--- a/.github/workflows/vcpkg_ci_windows.yml
+++ b/.github/workflows/vcpkg_ci_windows.yml
@@ -93,7 +93,7 @@ jobs:
           git -C "${env:VCPKG_ROOT}" checkout ${{ steps.vcpkg_info.outputs.commit }}
           for (($i = 0); $i -lt 3 -and !(Test-Path "${env:VCPKG_ROOT}\vcpkg.exe"); $i++)
           {
-            & "${env:VCPKG_ROOT}\bootstrap-vcpkg.bat" || true
+            Write-Output 'Y' | & "${env:VCPKG_ROOT}\bootstrap-vcpkg.bat" || true
           }
         env:
           VCPKG_DISABLE_METRICS: 1


### PR DESCRIPTION
Occasionally vcpkg bootstrap will hang for 6 hours asking if we want to terminate. We say "yes" because we do a retry until the binary shows up.