### PR TITLE
Use timeout for windows bootstrap

### DIFF
--- a/.github/workflows/vcpkg_ci_windows.yml
+++ b/.github/workflows/vcpkg_ci_windows.yml
@@ -91,9 +91,20 @@ jobs:
         run: |
           git clone ${{ steps.vcpkg_info.outputs.repo_url }} "${env:VCPKG_ROOT}"
           git -C "${env:VCPKG_ROOT}" checkout ${{ steps.vcpkg_info.outputs.commit }}
+          # Keep trying to bootstrap until we see the executable
           for (($i = 0); $i -lt 3 -and !(Test-Path "${env:VCPKG_ROOT}\vcpkg.exe"); $i++)
           {
-            Write-Output 'Y' | & "${env:VCPKG_ROOT}\bootstrap-vcpkg.bat" || true
+            $proc = Start-Process "${env:VCPKG_ROOT}\bootstrap-vcpkg.bat" -PassThru
+            # keep track of timeout event
+            $timeouted = $null # reset any previously set timeout
+            # wait up to 360 seconds for normal termination
+            $proc | Wait-Process -Timeout 360 -ErrorAction SilentlyContinue -ErrorVariable timeouted
+
+            if ($timeouted)
+            {
+                # terminate the process
+                $proc | kill
+            }
           }
         env:
           VCPKG_DISABLE_METRICS: 1


### PR DESCRIPTION
For some reason the bootstrap script is very flaky. Let's just manually keep track of it