### PR TITLE
Get ASan builds working for M1 Mac

### DIFF
--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -124,7 +124,7 @@ arch="$(uname -m)"
 triplet_os="linux"
 triplet_arch="x64"
 
-if [[ "${arch}" = "aarch64" ]]; then
+if [[ "${arch}" == "aarch64" || "${arch}" = "arm64" ]]; then
   triplet_arch="arm64"
 elif [[ "${arch}" = "x86_64" ]]; then
   triplet_arch="x64"

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -124,7 +124,7 @@ arch="$(uname -m)"
 triplet_os="linux"
 triplet_arch="x64"
 
-if [[ "${arch}" == "aarch64" || "${arch}" = "arm64" ]]; then
+if [[ "${arch}" = "aarch64" || "${arch}" = "arm64" ]]; then
   triplet_arch="arm64"
 elif [[ "${arch}" = "x86_64" ]]; then
   triplet_arch="x64"

--- a/ports/xed/portfile.cmake
+++ b/ports/xed/portfile.cmake
@@ -11,8 +11,8 @@ vcpkg_from_github(
 vcpkg_from_github(
     OUT_SOURCE_PATH MBUILD_SOURCE_PATH
     REPO intelxed/mbuild
-    REF f01087a20b6ac4bd99f7a7018ac467c2d54d3d2b
-    SHA512 1f2ea4f1622907bd4aa63329b1b557a75f10dd68b7d22cbb2f4b674e50a7fc643fe2e4e9d0101c0d7dbae280ad559c2d4a3f7f84cf2f491efeffec77f823c3d2
+    REF 3e8eb33aada4153c21c4261b35e5f51f6e2019e8
+    SHA512 ed3a705204a5f9526473280fdb64820aeec23b2da850dc3c78b83e6ccc7cd72961990fab0a0188c249d967b59f3d2cb00f6dcd3f9cceb7c30aa13e378e26ccd5
     HEAD_REF master
 )
 

--- a/triplets/arm64-osx-asan.cmake
+++ b/triplets/arm64-osx-asan.cmake
@@ -1,0 +1,17 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+# ASAN
+# Make sure this value matches up with https://llvm.org/docs/CMake.html "LLVM_USE_SANITIZER"
+set(VCPKG_USE_SANITIZER "Address")
+# If the following flags cause errors during build, you might need to manually
+# ignore the PORT and check VCPKG_USE_SANITIZER
+if(NOT PORT MATCHES "(llvm-*)")
+  set(VCPKG_CXX_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections -Wl,-undefined,dynamic_lookup")
+  set(VCPKG_C_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections -Wl,-undefined,dynamic_lookup")
+  set(VCPKG_LINKER_FLAGS "-fsanitize=address -Wl,-undefined,dynamic_lookup")
+endif()
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)


### PR DESCRIPTION
Hi @ekilmer. I'm on an M1 Mac and had to make these changes to get `cxx-common` building.

I only added an ASan configuration since that's the one I intended to build. I can add others too like `arm64-osx-rel.cmake` but it will take me a while to verify them since the build takes ages.