### PR TITLE
[llvm 9,10,11] Fix missing header (#820)

### DIFF
--- a/ports/llvm-10/0026-fix-missing-header-limits.patch
+++ b/ports/llvm-10/0026-fix-missing-header-limits.patch
@@ -1,0 +1,12 @@
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..4caa5ad4da07 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"

--- a/ports/llvm-10/portfile.cmake
+++ b/ports/llvm-10/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_from_github(
         0023-fix-macos-libcxx-header-handling.patch
         0024-vcpkg-fix-clang-sys-include-dir-path.patch
         0025-remove-compiler-rt-tests.patch
+        0026-fix-missing-header-limits.patch
 )
 
 include("${CURRENT_INSTALLED_DIR}/share/llvm-vcpkg-common/llvm-common-build.cmake")

--- a/ports/llvm-11/0025-fix-missing-header-limits.patch
+++ b/ports/llvm-11/0025-fix-missing-header-limits.patch
@@ -1,0 +1,12 @@
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..4caa5ad4da07 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"

--- a/ports/llvm-11/portfile.cmake
+++ b/ports/llvm-11/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_from_github(
         0022-llvm-config-bin-path.patch
         0023-fix-macos-libcxx-header-handling.patch
         0024-vcpkg-fix-clang-sys-include-dir-path.patch
+        0025-fix-missing-header-limits.patch
 )
 
 include("${CURRENT_INSTALLED_DIR}/share/llvm-vcpkg-common/llvm-common-build.cmake")

--- a/ports/llvm-9/0029-fix-missing-header-limits.patch
+++ b/ports/llvm-9/0029-fix-missing-header-limits.patch
@@ -1,0 +1,12 @@
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..4caa5ad4da07 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"

--- a/ports/llvm-9/portfile.cmake
+++ b/ports/llvm-9/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_from_github(
         0026-fix-macos-libcxx-header-handling.patch
         0027-vcpkg-fix-clang-sys-include-dir-path.patch
         0028-remove-compiler-rt-tests.patch
+        0029-fix-missing-header-limits.patch
 )
 
 include("${CURRENT_INSTALLED_DIR}/share/llvm-vcpkg-common/llvm-common-build.cmake")


### PR DESCRIPTION
* LLVM patch: https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1