### PR TITLE
Build cxx-common architecture targets

### DIFF
--- a/ports/llvm-12/vcpkg.json
+++ b/ports/llvm-12/vcpkg.json
@@ -19,8 +19,9 @@
     "clang",
     "compiler-rt",
     "default-options",
-    "default-targets",
+    "cxx-common-targets",
     "libcxx",
+    "libcxxabi",
     "mlir",
     "tools"
   ],
@@ -58,6 +59,22 @@
             "enable-threads",
             "enable-z3",
             "enable-zlib"
+          ]
+        }
+      ]
+    },
+    "cxx-common-targets": {
+      "description": "Build with cxx-common target set",
+      "dependencies": [
+        {
+          "name": "llvm-12",
+          "default-features": false,
+          "features": [
+            "target-aarch64",
+            "target-arm",
+            "target-nvptx",
+            "target-sparc",
+            "target-x86"
           ]
         }
       ]

--- a/ports/llvm-13/vcpkg.json
+++ b/ports/llvm-13/vcpkg.json
@@ -19,8 +19,9 @@
     "clang",
     "compiler-rt",
     "default-options",
-    "default-targets",
+    "cxx-common-targets",
     "libcxx",
+    "libcxxabi",
     "mlir",
     "tools"
   ],
@@ -58,6 +59,22 @@
             "enable-threads",
             "enable-z3",
             "enable-zlib"
+          ]
+        }
+      ]
+    },
+    "cxx-common-targets": {
+      "description": "Build with cxx-common target set",
+      "dependencies": [
+        {
+          "name": "llvm-13",
+          "default-features": false,
+          "features": [
+            "target-aarch64",
+            "target-arm",
+            "target-nvptx",
+            "target-sparc",
+            "target-x86"
           ]
         }
       ]


### PR DESCRIPTION
Build cxx-common architecture targets when building llvm via vcpkg.json. Fixes the issue where our tools can't link against things like `libLLVMAArch64*`