### PR TITLE
Fix vcpkg default host triplet

### DIFF
--- a/.github/workflows/vcpkg_ci_linux.yml
+++ b/.github/workflows/vcpkg_ci_linux.yml
@@ -58,6 +58,7 @@ jobs:
 
     env:
       ARTIFACT_NAME: vcpkg_${{ matrix.image.name }}-${{ matrix.image.tag }}_${{ matrix.llvm }}_${{ matrix.host.arch }}.tar.xz
+      VCPKG_DEFAULT_HOST_TRIPLET: ${{ matrix.host.triplet }}
 
     steps:
       # Used to get commit message since PRs are on a merge commit

--- a/.github/workflows/vcpkg_ci_mac.yml
+++ b/.github/workflows/vcpkg_ci_mac.yml
@@ -4,6 +4,7 @@ env:
   # "Source" is set in the setup-dotnet action
   VCPKG_BINARY_SOURCES: 'clear;nuget,Source,readwrite;nugettimeout,3601'
   TRIPLET: 'x64-osx-rel'
+  VCPKG_DEFAULT_HOST_TRIPLET: 'x64-osx-rel'
 
 on:
   release:

--- a/.github/workflows/vcpkg_ci_windows.yml
+++ b/.github/workflows/vcpkg_ci_windows.yml
@@ -4,6 +4,7 @@ env:
   # "Source" is set in the setup-dotnet action
   VCPKG_BINARY_SOURCES: 'clear;nuget,Source,readwrite;nugettimeout,3601'
   TRIPLET: 'x64-windows-static-md-rel'
+  VCPKG_DEFAULT_HOST_TRIPLET: 'x64-windows-static-md-rel'
 
 on:
   release:


### PR DESCRIPTION
This should fix duplicate builds of dependencies that use the host
triplet, so now only the release triplet should show up in the vcpkg
installed directory