### PR TITLE
Improve Emscripten support

### DIFF
--- a/ports/flatbuffers/emscripten-nostdlib.patch
+++ b/ports/flatbuffers/emscripten-nostdlib.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ec782239..57566c5a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -390,7 +390,7 @@
+   if (HAVE_SYMBOLIZE)
+     set (HAVE_STACKTRACE 1)
+   endif (HAVE_SYMBOLIZE)
+-elseif (UNIX OR (APPLE AND HAVE_DLADDR))
++elseif ((UNIX OR (APPLE AND HAVE_DLADDR)) AND NOT EMSCRIPTEN)
+   set (HAVE_SYMBOLIZE 1)
+ endif (WIN32 OR CYGWIN)
+

--- a/ports/flatbuffers/emscripten-nostdlib.patch
+++ b/ports/flatbuffers/emscripten-nostdlib.patch
@@ -2,12 +2,12 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index ec782239..57566c5a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -390,7 +390,7 @@
-   if (HAVE_SYMBOLIZE)
-     set (HAVE_STACKTRACE 1)
-   endif (HAVE_SYMBOLIZE)
--elseif (UNIX OR (APPLE AND HAVE_DLADDR))
-+elseif ((UNIX OR (APPLE AND HAVE_DLADDR)) AND NOT EMSCRIPTEN)
-   set (HAVE_SYMBOLIZE 1)
- endif (WIN32 OR CYGWIN)
-
+@@ -262,7 +262,7 @@
+   if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.8)
+     list(APPEND FLATBUFFERS_PRIVATE_CXX_FLAGS "-Wimplicit-fallthrough" "-Wextra-semi" "-Werror=unused-private-field") # enable warning
+   endif()
+-  if(FLATBUFFERS_LIBCXX_WITH_CLANG)
++  if(FLATBUFFERS_LIBCXX_WITH_CLANG AND NOT EMSCRIPTEN)
+     if(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+       set(CMAKE_CXX_FLAGS
+           "${CMAKE_CXX_FLAGS} -stdlib=libc++")

--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         ignore_use_of_cmake_toolchain_file.patch
         no-werror.patch
         fix-uwp-build.patch
+        windows-python.patch
 )
 
 set(OPTIONS)

--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         no-werror.patch
         fix-uwp-build.patch
         windows-python.patch
+        emscripten-nostdlib.patch
 )
 
 set(OPTIONS)

--- a/ports/flatbuffers/windows-python.patch
+++ b/ports/flatbuffers/windows-python.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ec782239..57566c5a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -488,7 +488,7 @@
+   # https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html
+   (WIN32 AND MSVC_VERSION GREATER 1800))
+   if(WIN32)
+-    set(GENERATION_SCRIPT py scripts/generate_code.py)
++    set(GENERATION_SCRIPT ${PYTHON_EXECUTABLE} scripts/generate_code.py)
+    else()
+     set(GENERATION_SCRIPT scripts/generate_code.py)
+   endif()

--- a/ports/glog/emscripten-no-symbolize.patch
+++ b/ports/glog/emscripten-no-symbolize.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 808330e..de0e477 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -390,7 +390,7 @@
+   if (HAVE_SYMBOLIZE)
+     set (HAVE_STACKTRACE 1)
+   endif (HAVE_SYMBOLIZE)
+-elseif (UNIX OR (APPLE AND HAVE_DLADDR))
++elseif ((UNIX OR (APPLE AND HAVE_DLADDR)) AND NOT EMSCRIPTEN)
+   set (HAVE_SYMBOLIZE 1)
+ endif (WIN32 OR CYGWIN)
+ 

--- a/ports/glog/emscripten-raw-logging.patch
+++ b/ports/glog/emscripten-raw-logging.patch
@@ -1,0 +1,13 @@
+diff --git a/src/raw_logging.cc b/src/raw_logging.cc
+index 808330e..de0e477 100644
+--- a/src/raw_logging.cc
++++ b/src/raw_logging.cc
+@@ -59,7 +59,7 @@
+ # include <unistd.h>
+ #endif
+ 
+-#if defined(HAVE_SYSCALL_H) || defined(HAVE_SYS_SYSCALL_H)
++#if (defined(HAVE_SYSCALL_H) || defined(HAVE_SYS_SYSCALL_H)) && !defined(EMSCRIPTEN)
+ # define safe_write(fd, s, len)  syscall(SYS_write, fd, s, len)
+ #else
+   // Not so safe, but what can you do?

--- a/ports/glog/glog_disable_debug_postfix.patch
+++ b/ports/glog/glog_disable_debug_postfix.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 808330e..de0e477 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -44,7 +44,7 @@ include (CTest)
+ include (DetermineGflagsNamespace)
+ include (GNUInstallDirs)
+ 
+-set (CMAKE_DEBUG_POSTFIX d)
++#set (CMAKE_DEBUG_POSTFIX d)
+ set (CMAKE_THREAD_PREFER_PTHREAD 1)
+ 
+ if (WITH_GFLAGS)

--- a/ports/glog/portfile.cmake
+++ b/ports/glog/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/glog
+    REF v0.4.0
+    SHA512 b585f1819ade2075f6b61dc5aaca5c3f9d25601dba2bd08b6c49b96ac5f79db23c6b7f2042df003f7130497dd7241fcaa8b107d1f97385cb66ce52d3c554b176
+    HEAD_REF master
+    PATCHES
+	   emscripten-no-symbolize.patch
+	   emscripten-raw-logging.patch
+       glog_disable_debug_postfix.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/glog)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+vcpkg_copy_pdbs()
+
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/glog/vcpkg.json
+++ b/ports/glog/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "glog",
+  "version-string": "0.4.0",
+  "port-version": 4,
+  "description": "C++ implementation of the Google logging module",
+  "homepage": "https://github.com/google/glog",
+  "dependencies": [
+    "gflags"
+  ]
+}

--- a/ports/llvm-12-libs/0020-remove-FindZ3.cmake.patch
+++ b/ports/llvm-12-libs/0020-remove-FindZ3.cmake.patch
@@ -1,0 +1,116 @@
+diff --git a/llvm/cmake/modules/FindZ3.cmake b/llvm/cmake/modules/FindZ3.cmake
+deleted file mode 100644
+index 95dd37789..000000000
+--- a/llvm/cmake/modules/FindZ3.cmake
++++ /dev/null
+@@ -1,110 +0,0 @@
+-INCLUDE(CheckCXXSourceRuns)
+-
+-# Function to check Z3's version
+-function(check_z3_version z3_include z3_lib)
+-  # The program that will be executed to print Z3's version.
+-  file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testz3.c
+-       "#include <assert.h>
+-        #include <z3.h>
+-        int main() {
+-          unsigned int major, minor, build, rev;
+-          Z3_get_version(&major, &minor, &build, &rev);
+-          printf(\"%u.%u.%u\", major, minor, build);
+-          return 0;
+-       }")
+-
+-  # Get lib path
+-  get_filename_component(z3_lib_path ${z3_lib} PATH)
+-
+-  try_run(
+-    Z3_RETURNCODE
+-    Z3_COMPILED
+-    ${CMAKE_BINARY_DIR}
+-    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testz3.c
+-    COMPILE_DEFINITIONS -I"${z3_include}"
+-    LINK_LIBRARIES -L${z3_lib_path} -lz3
+-    RUN_OUTPUT_VARIABLE SRC_OUTPUT
+-  )
+-
+-  if(Z3_COMPILED)
+-    string(REGEX REPLACE "([0-9]*\\.[0-9]*\\.[0-9]*)" "\\1"
+-           z3_version "${SRC_OUTPUT}")
+-    set(Z3_VERSION_STRING ${z3_version} PARENT_SCOPE)
+-  endif()
+-endfunction(check_z3_version)
+-
+-# Looking for Z3 in LLVM_Z3_INSTALL_DIR
+-find_path(Z3_INCLUDE_DIR NAMES z3.h
+-  NO_DEFAULT_PATH
+-  PATHS ${LLVM_Z3_INSTALL_DIR}/include
+-  PATH_SUFFIXES libz3 z3
+-  )
+-
+-find_library(Z3_LIBRARIES NAMES z3 libz3
+-  NO_DEFAULT_PATH
+-  PATHS ${LLVM_Z3_INSTALL_DIR}
+-  PATH_SUFFIXES lib bin
+-  )
+-
+-# If Z3 has not been found in LLVM_Z3_INSTALL_DIR look in the default directories
+-find_path(Z3_INCLUDE_DIR NAMES z3.h
+-  PATH_SUFFIXES libz3 z3
+-  )
+-
+-find_library(Z3_LIBRARIES NAMES z3 libz3
+-  PATH_SUFFIXES lib bin
+-  )
+-
+-# Searching for the version of the Z3 library is a best-effort task
+-unset(Z3_VERSION_STRING)
+-
+-# First, try to check it dynamically, by compiling a small program that
+-# prints Z3's version
+-if(Z3_INCLUDE_DIR AND Z3_LIBRARIES)
+-  # We do not have the Z3 binary to query for a version. Try to use
+-  # a small C++ program to detect it via the Z3_get_version() API call.
+-  check_z3_version(${Z3_INCLUDE_DIR} ${Z3_LIBRARIES})
+-endif()
+-
+-# If the dynamic check fails, we might be cross compiling: if that's the case,
+-# check the version in the headers, otherwise, fail with a message
+-if(NOT Z3_VERSION_STRING AND (CMAKE_CROSSCOMPILING AND
+-                              Z3_INCLUDE_DIR AND
+-                              EXISTS "${Z3_INCLUDE_DIR}/z3_version.h"))
+-  # TODO: print message warning that we couldn't find a compatible lib?
+-
+-  # Z3 4.8.1+ has the version is in a public header.
+-  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
+-       z3_version_str REGEX "^#define[\t ]+Z3_MAJOR_VERSION[\t ]+.*")
+-  string(REGEX REPLACE "^.*Z3_MAJOR_VERSION[\t ]+([0-9]).*$" "\\1"
+-         Z3_MAJOR "${z3_version_str}")
+-
+-  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
+-       z3_version_str REGEX "^#define[\t ]+Z3_MINOR_VERSION[\t ]+.*")
+-  string(REGEX REPLACE "^.*Z3_MINOR_VERSION[\t ]+([0-9]).*$" "\\1"
+-         Z3_MINOR "${z3_version_str}")
+-
+-  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
+-       z3_version_str REGEX "^#define[\t ]+Z3_BUILD_NUMBER[\t ]+.*")
+-  string(REGEX REPLACE "^.*Z3_BUILD_VERSION[\t ]+([0-9]).*$" "\\1"
+-         Z3_BUILD "${z3_version_str}")
+-
+-  set(Z3_VERSION_STRING ${Z3_MAJOR}.${Z3_MINOR}.${Z3_BUILD})
+-  unset(z3_version_str)
+-endif()
+-
+-if(NOT Z3_VERSION_STRING)
+-  # Give up: we are unable to obtain a version of the Z3 library. Be
+-  # conservative and force the found version to 0.0.0 to make version
+-  # checks always fail.
+-  set(Z3_VERSION_STRING "0.0.0")
+-endif()
+-
+-# handle the QUIETLY and REQUIRED arguments and set Z3_FOUND to TRUE if
+-# all listed variables are TRUE
+-include(FindPackageHandleStandardArgs)
+-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Z3
+-                                  REQUIRED_VARS Z3_LIBRARIES Z3_INCLUDE_DIR
+-                                  VERSION_VAR Z3_VERSION_STRING)
+-
+-mark_as_advanced(Z3_INCLUDE_DIR Z3_LIBRARIES)

--- a/ports/llvm-12-libs/0021-fix-FindZ3.cmake.patch
+++ b/ports/llvm-12-libs/0021-fix-FindZ3.cmake.patch
@@ -1,0 +1,151 @@
+diff --git a/llvm/cmake/modules/FindZ3.cmake b/llvm/cmake/modules/FindZ3.cmake
+new file mode 100644
+index 000000000..32f6f4160
+--- /dev/null
++++ b/llvm/cmake/modules/FindZ3.cmake
+@@ -0,0 +1,127 @@
++INCLUDE(CheckCXXSourceRuns)
++
++# Function to check Z3's version
++function(check_z3_version z3_include z3_lib)
++  # The program that will be executed to print Z3's version.
++  file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/testz3.c
++       "#include <assert.h>
++        #include <z3.h>
++        int main() {
++          unsigned int major, minor, build, rev;
++          Z3_get_version(&major, &minor, &build, &rev);
++          printf(\"%u.%u.%u\", major, minor, build);
++          return 0;
++       }")
++
++  # Try to find a threading module in case Z3 was built with threading support.
++  # Threads are required elsewhere in LLVM, but not marked as required here because
++  # Z3 could have been compiled without threading support.
++  find_package(Threads)
++  set(z3_link_libs ${z3_lib} "${CMAKE_THREAD_LIBS_INIT}")
++
++  # Get lib path
++  get_filename_component(z3_lib_path ${z3_lib} PATH)
++
++  try_run(
++    Z3_RETURNCODE
++    Z3_COMPILED
++    ${CMAKE_BINARY_DIR}
++    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/testz3.c
++    COMPILE_DEFINITIONS -I"${z3_include}"
++    LINK_LIBRARIES -L${z3_lib_path} ${z3_link_libs}
++    RUN_OUTPUT_VARIABLE SRC_OUTPUT
++  )
++
++  if(Z3_COMPILED)
++    string(REGEX REPLACE "([0-9]*\\.[0-9]*\\.[0-9]*)" "\\1"
++           z3_version "${SRC_OUTPUT}")
++    set(Z3_VERSION_STRING ${z3_version} PARENT_SCOPE)
++  endif()
++endfunction(check_z3_version)
++
++# Looking for Z3 in LLVM_Z3_INSTALL_DIR
++find_path(Z3_INCLUDE_DIR NAMES z3.h
++  NO_DEFAULT_PATH
++  PATHS ${LLVM_Z3_INSTALL_DIR}/include
++  PATH_SUFFIXES libz3 z3
++  )
++
++find_library(Z3_LIBS NAMES z3 libz3
++  NO_DEFAULT_PATH
++  PATHS ${LLVM_Z3_INSTALL_DIR}
++  PATH_SUFFIXES lib bin
++  )
++
++# If Z3 has not been found in LLVM_Z3_INSTALL_DIR look in the default directories
++find_path(Z3_INCLUDE_DIR NAMES z3.h
++  PATH_SUFFIXES libz3 z3
++  )
++
++find_library(Z3_LIBS NAMES z3 libz3
++  PATH_SUFFIXES lib bin
++  )
++
++# Searching for the version of the Z3 library is a best-effort task
++unset(Z3_VERSION_STRING)
++
++# First, try to check it dynamically, by compiling a small program that
++# prints Z3's version
++if(Z3_INCLUDE_DIR AND Z3_LIBS)
++  # We do not have the Z3 binary to query for a version. Try to use
++  # a small C++ program to detect it via the Z3_get_version() API call.
++  check_z3_version(${Z3_INCLUDE_DIR} ${Z3_LIBS})
++endif()
++
++# If the dynamic check fails, we might be cross compiling: if that's the case,
++# check the version in the headers, otherwise, fail with a message
++if(EXISTS "${Z3_INCLUDE_DIR}/z3_version.h" AND (NOT Z3_VERSION_STRING OR
++                              (CMAKE_CROSSCOMPILING AND
++                              Z3_INCLUDE_DIR)))
++  # TODO: print message warning that we couldn't find a compatible lib?
++
++  # Z3 4.8.1+ has the version is in a public header.
++  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
++       z3_version_str REGEX "^#define[\t ]+Z3_MAJOR_VERSION[\t ]+.*")
++  string(REGEX REPLACE "^.*Z3_MAJOR_VERSION[\t ]+([0-9]+).*$" "\\1"
++         Z3_MAJOR "${z3_version_str}")
++
++  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
++       z3_version_str REGEX "^#define[\t ]+Z3_MINOR_VERSION[\t ]+.*")
++  string(REGEX REPLACE "^.*Z3_MINOR_VERSION[\t ]+([0-9]+).*$" "\\1"
++         Z3_MINOR "${z3_version_str}")
++
++  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
++       z3_version_str REGEX "^#define[\t ]+Z3_BUILD_NUMBER[\t ]+.*")
++  string(REGEX REPLACE "^.*Z3_BUILD_NUMBER[\t ]+([0-9]+).*$" "\\1"
++         Z3_BUILD "${z3_version_str}")
++
++  set(Z3_VERSION_STRING ${Z3_MAJOR}.${Z3_MINOR}.${Z3_BUILD})
++  unset(z3_version_str)
++endif()
++
++if(NOT Z3_VERSION_STRING)
++  # Give up: we are unable to obtain a version of the Z3 library. Be
++  # conservative and force the found version to 0.0.0 to make version
++  # checks always fail.
++  set(Z3_VERSION_STRING "0.0.0")
++endif()
++
++# handle the QUIETLY and REQUIRED arguments and set Z3_FOUND to TRUE if
++# all listed variables are TRUE
++include(FindPackageHandleStandardArgs)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(Z3
++                                  REQUIRED_VARS Z3_LIBS Z3_INCLUDE_DIR
++                                  VERSION_VAR Z3_VERSION_STRING)
++
++if(Z3_FOUND AND NOT TARGET Z3)
++  add_library(Z3 UNKNOWN IMPORTED)
++  set_target_properties(Z3 PROPERTIES
++    INTERFACE_INCLUDE_DIRECTORIES "${Z3_INCLUDE_DIR}"
++    IMPORTED_LOCATION "${Z3_LIBS}"
++  )
++  set(Z3_LIBRARIES "Z3")
++  set(THREADS_PREFER_PTHREAD_FLAG ON)
++  find_package(Threads REQUIRED)
++  target_link_libraries(Z3 INTERFACE Threads::Threads)
++endif()
++mark_as_advanced(Z3_INCLUDE_DIR Z3_LIBS Z3_LIBRARIES)
+diff --git a/llvm/cmake/modules/LLVMConfig.cmake.in b/llvm/cmake/modules/LLVMConfig.cmake.in
+index ac053141b008..150b748aa491 100644
+--- a/llvm/cmake/modules/LLVMConfig.cmake.in
++++ b/llvm/cmake/modules/LLVMConfig.cmake.in
+@@ -65,6 +65,13 @@ if(LLVM_ENABLE_LIBXML2)
+ endif()
+ 
+ set(LLVM_WITH_Z3 @LLVM_WITH_Z3@)
++if(LLVM_WITH_Z3)
++  # Need to use our FindModule instead of another one (like the one included
++  # with later versions of Z3
++  list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
++  find_package(Z3 4.7.1 REQUIRED)
++  list(POP_FRONT CMAKE_MODULE_PATH)
++endif()
+ 
+ set(LLVM_ENABLE_DIA_SDK @LLVM_ENABLE_DIA_SDK@)
+ 

--- a/ports/llvm-12-libs/0022-fix-emscripten.patch
+++ b/ports/llvm-12-libs/0022-fix-emscripten.patch
@@ -1,0 +1,69 @@
+diff --git a/llvm/cmake/modules/GetHostTriple.cmake b/llvm/cmake/modules/GetHostTriple.cmake
+index eb7bd4aec898..878a49c3cfb8 100644
+--- a/llvm/cmake/modules/GetHostTriple.cmake
++++ b/llvm/cmake/modules/GetHostTriple.cmake
+@@ -41,6 +41,8 @@
+     else()
+       set( value "powerpc-ibm-aix" )
+     endif()
++  elseif( EMSCRIPTEN )
++    set ( value "wasm32" )
+   else( MSVC )
+     if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows AND NOT MSYS)
+       message(WARNING "unable to determine host target triple")
+diff --git a/libcxx/CMakeLists.txt b/libcxx/CMakeLists.txt
+index eb7bd4aec898..878a49c3cfb8 100644
+--- a/libcxx/CMakeLists.txt
++++ b/libcxx/CMakeLists.txt
+@@ -89,6 +89,9 @@
+ option(LIBCXX_ENABLE_SHARED "Build libc++ as a shared library." ON)
+ option(LIBCXX_ENABLE_STATIC "Build libc++ as a static library." ON)
+ option(LIBCXX_ENABLE_EXPERIMENTAL_LIBRARY "Build libc++experimental.a" ON)
++if(EMSCRIPTEN)
++  set(LIBCXX_ENABLE_SHARED OFF)
++endif()
+ set(ENABLE_FILESYSTEM_DEFAULT ON)
+ if (WIN32)
+   set(ENABLE_FILESYSTEM_DEFAULT OFF)
+diff --git a/libcxxabi/CMakeLists.txt b/libcxxabi/CMakeLists.txt
+index eb7bd4aec898..878a49c3cfb8 100644
++++ b/libcxxabi/CMakeLists.txt
+--- a/libcxxabi/CMakeLists.txt
+@@ -129,6 +129,9 @@
+ # system over a static libc++abi from the output directory.
+ option(LIBCXXABI_ENABLE_SHARED "Build libc++abi as a shared library." ON)
+ option(LIBCXXABI_ENABLE_STATIC "Build libc++abi as a static library." ON)
++if(EMSCRIPTEN)
++  set(LIBCXXABI_ENABLE_SHARED OFF)
++endif()
+ 
+ cmake_dependent_option(LIBCXXABI_INSTALL_STATIC_LIBRARY
+   "Install the static libc++abi library." ON
+diff --git a/llvm/cmake/modules/HandleLLVMOptions.cmake b/llvm/cmake/modules/HandleLLVMOptions.cmake
+index eb7bd4aec898..878a49c3cfb8 100644
++++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
+--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+@@ -131,6 +131,10 @@
+     set(LLVM_ON_WIN32 1)
+     set(LLVM_ON_UNIX 0)
+   endif(CYGWIN)
++elseif(EMSCRIPTEN)
++  set(LLVM_HAVE_LINK_VERSION_SCRIPT 0)
++  set(LLVM_ON_WIN32 0)
++  set(LLVM_ON_UNIX 1)
+ else(WIN32)
+   if(FUCHSIA OR UNIX)
+     set(LLVM_ON_WIN32 0)
+diff --git a/llvm/cmake/modules/TableGen.cmake b/llvm/cmake/modules/TableGen.cmake
+index eb7bd4aec898..878a49c3cfb8 100644
++++ b/llvm/cmake/modules/TableGen.cmake
+--- a/llvm/cmake/modules/TableGen.cmake
+@@ -176,7 +176,7 @@
+     endif()
+   endif()
+ 
+-  if ((${project} STREQUAL LLVM OR ${project} STREQUAL MLIR) AND NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND LLVM_BUILD_UTILS)
++  if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND LLVM_BUILD_UTILS)
+     set(export_to_llvmexports)
+     if(${target} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+         NOT LLVM_DISTRIBUTION_COMPONENTS)

--- a/ports/llvm-12-libs/vcpkg.json
+++ b/ports/llvm-12-libs/vcpkg.json
@@ -1,0 +1,43 @@
+{
+  "name": "llvm-12-libs",
+  "version": "12.0.1",
+  "description": "The LLVM Compiler Infrastructure.",
+  "homepage": "https://llvm.org",
+  "supports": "!uwp & !(arm & windows)",
+  "dependencies": [
+    {
+      "name": "llvm-12",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "clang",
+    "enable-z3"
+  ],
+  "features": {
+    "clang": {
+      "description": "Include C Language Family Front-end."
+    },
+    "enable-z3": {
+      "description": "Compile with Z3 SMT solver support for Clang static analyzer.",
+      "dependencies": [
+        "z3",
+        {
+          "name": "llvm-12-libs",
+          "default-features": false,
+          "features": [
+            "clang"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/ports/llvm-12/0024-install-clang-tblgen.patch
+++ b/ports/llvm-12/0024-install-clang-tblgen.patch
@@ -1,0 +1,13 @@
+diff --git a/llvm/cmake/modules/TableGen.cmake b/llvm/cmake/modules/TableGen.cmake
+index eb7bd4aec898..878a49c3cfb8 100644
++++ b/llvm/cmake/modules/TableGen.cmake
+--- a/llvm/cmake/modules/TableGen.cmake
+@@ -176,7 +176,7 @@
+     endif()
+   endif()
+ 
+-  if ((${project} STREQUAL LLVM OR ${project} STREQUAL MLIR) AND NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND LLVM_BUILD_UTILS)
++  if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND LLVM_BUILD_UTILS)
+     set(export_to_llvmexports)
+     if(${target} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+         NOT LLVM_DISTRIBUTION_COMPONENTS)

--- a/ports/llvm-12/portfile.cmake
+++ b/ports/llvm-12/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_from_github(
         0021-fix-FindZ3.cmake.patch
         0022-llvm-config-bin-path.patch
         0023-clang-sys-include-dir-path.patch
+        0024-install-clang-tblgen.patch
 )
 
 include("${CURRENT_INSTALLED_DIR}/share/llvm-vcpkg-common/llvm-common-build.cmake")

--- a/triplets/wasm32-emscripten-rel.cmake
+++ b/triplets/wasm32-emscripten-rel.cmake
@@ -1,0 +1,16 @@
+set(VCPKG_ENV_PASSTHROUGH EMSDK PATH)
+
+if(NOT DEFINED ENV{EMSDK})
+   message(FATAL_ERROR "The EMSDK environment variable must be defined")
+endif()
+
+if(NOT EXISTS $ENV{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake)
+   message(FATAL_ERROR "Emscripten.cmake toolchain file not found")
+endif()
+
+set(VCPKG_TARGET_ARCHITECTURE wasm32)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Emscripten)
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE $ENV{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake)
+set(VCPKG_BUILD_TYPE release)


### PR DESCRIPTION
Also fixes some Windows issues when building.

Requires `llvm-12[utils]` to be installed on the host triplet, as cross-compiling makes use of native `llvm-tblgen` and `clang-tblgen`