### PR TITLE
add LLVM relocation patch

### DIFF
--- a/ports/llvm-13/0024-remove-elf_relocation-checks.patch
+++ b/ports/llvm-13/0024-remove-elf_relocation-checks.patch
@@ -1,67 +1,114 @@
 diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
-index efe0b9cd61cd..80f7d1c4bc91 100644
+index efe0b9cd61cd..8d1f2fa1ccc1 100644
 --- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
 +++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
-@@ -262,7 +262,7 @@ void RuntimeDyldELF::resolveX86_64Relocation(const SectionEntry &Section,
+@@ -21,6 +21,7 @@
+ #include "llvm/Object/ObjectFile.h"
+ #include "llvm/Support/Endian.h"
+ #include "llvm/Support/MemoryBuffer.h"
++#include "llvm/Support/raw_ostream.h"
+ 
+ using namespace llvm;
+ using namespace llvm::object;
+@@ -28,6 +29,17 @@ using namespace llvm::support::endian;
+ 
+ #define DEBUG_TYPE "dyld"
+ 
++static void report_reallocation_error(uint32_t ty) {
++  std::string message;
++  llvm::raw_string_ostream ss(message);
++  ss << "Relocation type not implemented yet: " << ty << "!";
++  if (RuntimeDyldELF::ShouldFailOnRelocationErrors) {
++    report_fatal_error(message);
++  } else {
++    dbgs() << message;
++  }
++}
++
+ static void or32le(void *P, int32_t V) { write32le(P, read32le(P) | V); }
+ 
+ static void or32AArch64Imm(void *L, uint64_t Imm) {
+@@ -262,7 +274,7 @@ void RuntimeDyldELF::resolveX86_64Relocation(const SectionEntry &Section,
                                               uint64_t SymOffset) {
    switch (Type) {
    default:
 -    report_fatal_error("Relocation type not implemented yet!");
-+    //report_fatal_error("Relocation type not implemented yet!");
++    report_reallocation_error(Type);
      break;
    case ELF::R_X86_64_NONE:
      break;
-@@ -371,7 +371,7 @@ void RuntimeDyldELF::resolveX86Relocation(const SectionEntry &Section,
+@@ -371,7 +383,7 @@ void RuntimeDyldELF::resolveX86Relocation(const SectionEntry &Section,
    default:
      // There are other relocation types, but it appears these are the
      // only ones currently used by the LLVM ELF object writer
 -    report_fatal_error("Relocation type not implemented yet!");
-+    //report_fatal_error("Relocation type not implemented yet!");
++    report_reallocation_error(Type);
      break;
    }
  }
-@@ -394,7 +394,7 @@ void RuntimeDyldELF::resolveAArch64Relocation(const SectionEntry &Section,
+@@ -394,7 +406,7 @@ void RuntimeDyldELF::resolveAArch64Relocation(const SectionEntry &Section,
  
    switch (Type) {
    default:
 -    report_fatal_error("Relocation type not implemented yet!");
-+    //report_fatal_error("Relocation type not implemented yet!");
++    report_reallocation_error(Type);
      break;
    case ELF::R_AARCH64_ABS16: {
      uint64_t Result = Value + Addend;
-@@ -779,7 +779,7 @@ void RuntimeDyldELF::resolvePPC32Relocation(const SectionEntry &Section,
+@@ -779,7 +791,7 @@ void RuntimeDyldELF::resolvePPC32Relocation(const SectionEntry &Section,
    uint8_t *LocalAddress = Section.getAddressWithOffset(Offset);
    switch (Type) {
    default:
 -    report_fatal_error("Relocation type not implemented yet!");
-+    //report_fatal_error("Relocation type not implemented yet!");
++    report_reallocation_error(Type);
      break;
    case ELF::R_PPC_ADDR16_LO:
      writeInt16BE(LocalAddress, applyPPClo(Value + Addend));
-@@ -799,7 +799,7 @@ void RuntimeDyldELF::resolvePPC64Relocation(const SectionEntry &Section,
+@@ -799,7 +811,7 @@ void RuntimeDyldELF::resolvePPC64Relocation(const SectionEntry &Section,
    uint8_t *LocalAddress = Section.getAddressWithOffset(Offset);
    switch (Type) {
    default:
 -    report_fatal_error("Relocation type not implemented yet!");
-+    //report_fatal_error("Relocation type not implemented yet!");
++    report_reallocation_error(Type);
      break;
    case ELF::R_PPC64_ADDR16:
      writeInt16BE(LocalAddress, applyPPClo(Value + Addend));
-@@ -893,7 +893,7 @@ void RuntimeDyldELF::resolveSystemZRelocation(const SectionEntry &Section,
+@@ -893,7 +905,7 @@ void RuntimeDyldELF::resolveSystemZRelocation(const SectionEntry &Section,
    uint8_t *LocalAddress = Section.getAddressWithOffset(Offset);
    switch (Type) {
    default:
 -    report_fatal_error("Relocation type not implemented yet!");
-+    //report_fatal_error("Relocation type not implemented yet!");
++    report_reallocation_error(Type);
      break;
    case ELF::R_390_PC16DBL:
    case ELF::R_390_PLT16DBL: {
-@@ -948,7 +948,7 @@ void RuntimeDyldELF::resolveBPFRelocation(const SectionEntry &Section,
+@@ -948,7 +960,7 @@ void RuntimeDyldELF::resolveBPFRelocation(const SectionEntry &Section,
  
    switch (Type) {
    default:
 -    report_fatal_error("Relocation type not implemented yet!");
-+    //report_fatal_error("Relocation type not implemented yet!");
++    report_reallocation_error(Type);
      break;
    case ELF::R_BPF_NONE:
    case ELF::R_BPF_64_64:
+@@ -2031,4 +2043,6 @@ bool RuntimeDyldELF::relocationNeedsStub(const RelocationRef &R) const {
+   }
+ }
+ 
++bool RuntimeDyldELF::ShouldFailOnRelocationErrors = true;
++
+ } // namespace llvm
+diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.h b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.h
+index 31892b7466e6..2e17522fae45 100644
+--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.h
++++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.h
+@@ -162,6 +162,9 @@ private:
+   bool relocationNeedsStub(const RelocationRef &R) const override;
+ 
+ public:
++
++  static bool ShouldFailOnRelocationErrors;
++
+   RuntimeDyldELF(RuntimeDyld::MemoryManager &MemMgr,
+                  JITSymbolResolver &Resolver);
+   ~RuntimeDyldELF() override;

--- a/ports/llvm-13/0024-remove-elf_relocation-checks.patch
+++ b/ports/llvm-13/0024-remove-elf_relocation-checks.patch
@@ -1,0 +1,67 @@
+diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+index efe0b9cd61cd..80f7d1c4bc91 100644
+--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
++++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+@@ -262,7 +262,7 @@ void RuntimeDyldELF::resolveX86_64Relocation(const SectionEntry &Section,
+                                              uint64_t SymOffset) {
+   switch (Type) {
+   default:
+-    report_fatal_error("Relocation type not implemented yet!");
++    //report_fatal_error("Relocation type not implemented yet!");
+     break;
+   case ELF::R_X86_64_NONE:
+     break;
+@@ -371,7 +371,7 @@ void RuntimeDyldELF::resolveX86Relocation(const SectionEntry &Section,
+   default:
+     // There are other relocation types, but it appears these are the
+     // only ones currently used by the LLVM ELF object writer
+-    report_fatal_error("Relocation type not implemented yet!");
++    //report_fatal_error("Relocation type not implemented yet!");
+     break;
+   }
+ }
+@@ -394,7 +394,7 @@ void RuntimeDyldELF::resolveAArch64Relocation(const SectionEntry &Section,
+ 
+   switch (Type) {
+   default:
+-    report_fatal_error("Relocation type not implemented yet!");
++    //report_fatal_error("Relocation type not implemented yet!");
+     break;
+   case ELF::R_AARCH64_ABS16: {
+     uint64_t Result = Value + Addend;
+@@ -779,7 +779,7 @@ void RuntimeDyldELF::resolvePPC32Relocation(const SectionEntry &Section,
+   uint8_t *LocalAddress = Section.getAddressWithOffset(Offset);
+   switch (Type) {
+   default:
+-    report_fatal_error("Relocation type not implemented yet!");
++    //report_fatal_error("Relocation type not implemented yet!");
+     break;
+   case ELF::R_PPC_ADDR16_LO:
+     writeInt16BE(LocalAddress, applyPPClo(Value + Addend));
+@@ -799,7 +799,7 @@ void RuntimeDyldELF::resolvePPC64Relocation(const SectionEntry &Section,
+   uint8_t *LocalAddress = Section.getAddressWithOffset(Offset);
+   switch (Type) {
+   default:
+-    report_fatal_error("Relocation type not implemented yet!");
++    //report_fatal_error("Relocation type not implemented yet!");
+     break;
+   case ELF::R_PPC64_ADDR16:
+     writeInt16BE(LocalAddress, applyPPClo(Value + Addend));
+@@ -893,7 +893,7 @@ void RuntimeDyldELF::resolveSystemZRelocation(const SectionEntry &Section,
+   uint8_t *LocalAddress = Section.getAddressWithOffset(Offset);
+   switch (Type) {
+   default:
+-    report_fatal_error("Relocation type not implemented yet!");
++    //report_fatal_error("Relocation type not implemented yet!");
+     break;
+   case ELF::R_390_PC16DBL:
+   case ELF::R_390_PLT16DBL: {
+@@ -948,7 +948,7 @@ void RuntimeDyldELF::resolveBPFRelocation(const SectionEntry &Section,
+ 
+   switch (Type) {
+   default:
+-    report_fatal_error("Relocation type not implemented yet!");
++    //report_fatal_error("Relocation type not implemented yet!");
+     break;
+   case ELF::R_BPF_NONE:
+   case ELF::R_BPF_64_64:

--- a/ports/llvm-13/0024-remove-elf_relocation-checks.patch
+++ b/ports/llvm-13/0024-remove-elf_relocation-checks.patch
@@ -43,7 +43,7 @@ index efe0b9cd61cd..4f29726b2112 100644
 +static void report_reallocation_error(uint32_t ty) {
 +  std::string message;
 +  llvm::raw_string_ostream ss(message);
-+  ss << "Relocation type not implemented yet: " << ty << "!";
++  ss << "Relocation type not implemented yet: " << ty << "!\n";
 +  if (RuntimeDyld::ShouldFailOnRelocationErrors) {
 +    report_fatal_error(message);
 +  } else {

--- a/ports/llvm-13/0024-remove-elf_relocation-checks.patch
+++ b/ports/llvm-13/0024-remove-elf_relocation-checks.patch
@@ -1,5 +1,31 @@
+diff --git a/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h b/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
+index 128c9967a596..9dc2f6cf7f98 100644
+--- a/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
++++ b/llvm/include/llvm/ExecutionEngine/RuntimeDyld.h
+@@ -57,6 +57,10 @@ class RuntimeDyldImpl;
+ 
+ class RuntimeDyld {
+ public:
++  
++  // Should there be a hard failure on a relocation or just soft failure?
++  static bool ShouldFailOnRelocationErrors;
++
+   // Change the address associated with a section when resolving relocations.
+   // Any relocations already associated with the symbol will be re-resolved.
+   void reassignSectionAddress(unsigned SectionID, uint64_t Addr);
+diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+index 687fd839805f..2e9e1a2794ac 100644
+--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
++++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+@@ -1446,4 +1446,6 @@ void jitLinkForORC(
+                                  std::move(O), std::move(Info));
+ }
+ 
++bool RuntimeDyld::ShouldFailOnRelocationErrors = true;
++
+ } // end namespace llvm
 diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
-index efe0b9cd61cd..8d1f2fa1ccc1 100644
+index efe0b9cd61cd..4f29726b2112 100644
 --- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
 +++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
 @@ -21,6 +21,7 @@
@@ -18,7 +44,7 @@ index efe0b9cd61cd..8d1f2fa1ccc1 100644
 +  std::string message;
 +  llvm::raw_string_ostream ss(message);
 +  ss << "Relocation type not implemented yet: " << ty << "!";
-+  if (RuntimeDyldELF::ShouldFailOnRelocationErrors) {
++  if (RuntimeDyld::ShouldFailOnRelocationErrors) {
 +    report_fatal_error(message);
 +  } else {
 +    dbgs() << message;
@@ -91,23 +117,14 @@ index efe0b9cd61cd..8d1f2fa1ccc1 100644
      break;
    case ELF::R_BPF_NONE:
    case ELF::R_BPF_64_64:
-@@ -2031,4 +2043,6 @@ bool RuntimeDyldELF::relocationNeedsStub(const RelocationRef &R) const {
-   }
- }
- 
-+bool RuntimeDyldELF::ShouldFailOnRelocationErrors = true;
-+
- } // namespace llvm
 diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.h b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.h
-index 31892b7466e6..2e17522fae45 100644
+index 31892b7466e6..4a2cc70f0e96 100644
 --- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.h
 +++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.h
-@@ -162,6 +162,9 @@ private:
+@@ -162,6 +162,7 @@ private:
    bool relocationNeedsStub(const RelocationRef &R) const override;
  
  public:
-+
-+  static bool ShouldFailOnRelocationErrors;
 +
    RuntimeDyldELF(RuntimeDyld::MemoryManager &MemMgr,
                   JITSymbolResolver &Resolver);

--- a/ports/llvm-13/portfile.cmake
+++ b/ports/llvm-13/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
         0021-fix-FindZ3.cmake.patch
         0022-llvm-config-bin-path.patch
         0023-clang-sys-include-dir-path.patch
+        0024-remove-elf_relocation-checks.patch
 )
 
 include("${CURRENT_INSTALLED_DIR}/share/llvm-vcpkg-common/llvm-common-build.cmake")

--- a/ports/llvm-13/vcpkg.json
+++ b/ports/llvm-13/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "llvm-13",
   "version": "13.0.1",
+  "port-version": 1,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "supports": "!uwp & !(arm & windows)",

--- a/triplets/arm64-osx-asan.cmake
+++ b/triplets/arm64-osx-asan.cmake
@@ -2,6 +2,8 @@ set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
 
+
+set(VCPKG_LINKER_FLAGS "-fsanitize=address")
 # ASAN
 # Make sure this value matches up with https://llvm.org/docs/CMake.html "LLVM_USE_SANITIZER"
 set(VCPKG_USE_SANITIZER "Address")

--- a/triplets/arm64-osx-asan.cmake
+++ b/triplets/arm64-osx-asan.cmake
@@ -2,8 +2,6 @@ set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
 
-
-set(VCPKG_LINKER_FLAGS "-fsanitize=address")
 # ASAN
 # Make sure this value matches up with https://llvm.org/docs/CMake.html "LLVM_USE_SANITIZER"
 set(VCPKG_USE_SANITIZER "Address")

--- a/triplets/arm64-osx-asan.cmake
+++ b/triplets/arm64-osx-asan.cmake
@@ -8,7 +8,7 @@ set(VCPKG_USE_SANITIZER "Address")
 
 # If the following flags cause errors during build, you might need to manually
 # ignore the PORT and check VCPKG_USE_SANITIZER
-if(NOT PORT MATCHES "^((llvm)|(llvm-[0-9]+)|(upb))$")
+if(NOT PORT MATCHES "^((llvm)|(llvm-[0-9]+)|(upb)|(xed))$")
   set(VCPKG_CXX_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections")
   set(VCPKG_C_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections")
 endif()

--- a/triplets/arm64-osx-asan.cmake
+++ b/triplets/arm64-osx-asan.cmake
@@ -8,7 +8,7 @@ set(VCPKG_USE_SANITIZER "Address")
 
 # If the following flags cause errors during build, you might need to manually
 # ignore the PORT and check VCPKG_USE_SANITIZER
-if(NOT PORT MATCHES "^((llvm)|(llvm-[0-9]+)|(upb)|(xed))$")
+if(NOT PORT MATCHES "^((llvm)|(llvm-[0-9]+)|(upb))$")
   set(VCPKG_CXX_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections")
   set(VCPKG_C_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections")
 endif()


### PR DESCRIPTION
Im not happy merging this as is because it skips relocations that it is unable to apply in elfs without applying them. This should probably be gated behind a feature or something