### PR TITLE
Always add sanitizer flag when linking

### DIFF
--- a/triplets/arm64-osx-asan.cmake
+++ b/triplets/arm64-osx-asan.cmake
@@ -5,13 +5,16 @@ set(VCPKG_LIBRARY_LINKAGE static)
 # ASAN
 # Make sure this value matches up with https://llvm.org/docs/CMake.html "LLVM_USE_SANITIZER"
 set(VCPKG_USE_SANITIZER "Address")
+
 # If the following flags cause errors during build, you might need to manually
 # ignore the PORT and check VCPKG_USE_SANITIZER
 if(NOT PORT MATCHES "^((llvm)|(llvm-[0-9]+)|(upb))$")
   set(VCPKG_CXX_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections")
   set(VCPKG_C_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections")
-  set(VCPKG_LINKER_FLAGS "-fsanitize=address")
 endif()
+
+# Always apply sanitizer to linker flags
+set(VCPKG_LINKER_FLAGS "-fsanitize=address")
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES arm64)

--- a/triplets/x64-linux-rel-asan.cmake
+++ b/triplets/x64-linux-rel-asan.cmake
@@ -5,13 +5,16 @@ set(VCPKG_LIBRARY_LINKAGE static)
 # ASAN
 # Make sure this value matches up with https://llvm.org/docs/CMake.html "LLVM_USE_SANITIZER"
 set(VCPKG_USE_SANITIZER "Address")
+
 # If the following flags cause errors during build, you might need to manually
 # ignore the PORT and check VCPKG_USE_SANITIZER
 if(NOT PORT MATCHES "^((llvm)|(llvm-[0-9]+)|(upb))$")
   set(VCPKG_CXX_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections")
   set(VCPKG_C_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections")
-  set(VCPKG_LINKER_FLAGS "-fsanitize=address")
 endif()
+
+# Always apply sanitizer to linker flags
+set(VCPKG_LINKER_FLAGS "-fsanitize=address")
 
 # Only release builds
 set(VCPKG_BUILD_TYPE release)

--- a/triplets/x64-osx-rel-asan.cmake
+++ b/triplets/x64-osx-rel-asan.cmake
@@ -12,8 +12,10 @@ set(VCPKG_USE_SANITIZER "Address")
 if(NOT PORT MATCHES "^((llvm)|(llvm-[0-9]+)|(upb))$")
   set(VCPKG_CXX_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections")
   set(VCPKG_C_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -ffunction-sections -fdata-sections")
-  set(VCPKG_LINKER_FLAGS "-fsanitize=address")
 endif()
+
+# Always apply sanitizer to linker flags
+set(VCPKG_LINKER_FLAGS "-fsanitize=address")
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)


### PR DESCRIPTION
There were errors in LLVM without this