### PR TITLE
z3: vcpkg find Python3 instead of Python2

### DIFF
--- a/.github/workflows/vcpkg_ci_aws_amd64.yml
+++ b/.github/workflows/vcpkg_ci_aws_amd64.yml
@@ -202,7 +202,7 @@ jobs:
           scripts/roundtrip.py ${INSTALL_DIR}/install/bin/rellic-decomp* $(pwd)/tests/tools/decomp "${VCPKG_ROOT}/installed/${{ matrix.host.triplet }}/tools/llvm/clang"
 
       - name: 'Remill build'
-        if: ${{ matrix.llvm == 'llvm-13' }}
+        # if: ${{ matrix.llvm == 'llvm-13' }}
         shell: 'bash'
         run: |
           cd remill

--- a/.github/workflows/vcpkg_ci_aws_arm64.yml
+++ b/.github/workflows/vcpkg_ci_aws_arm64.yml
@@ -203,7 +203,7 @@ jobs:
           scripts/roundtrip.py ${INSTALL_DIR}/install/bin/rellic-decomp* $(pwd)/tests/tools/decomp "${VCPKG_ROOT}/installed/${{ matrix.host.triplet }}/tools/llvm/clang"
 
       - name: 'Remill build'
-        if: ${{ matrix.llvm == 'llvm-13' }}
+        # if: ${{ matrix.llvm == 'llvm-13' }}
         shell: 'bash'
         run: |
           cd remill

--- a/.github/workflows/vcpkg_ci_mac.yml
+++ b/.github/workflows/vcpkg_ci_mac.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: 'Remill build'
         shell: 'bash'
-        if: ${{ matrix.llvm == 'llvm-13' }}
+        # if: ${{ matrix.llvm == 'llvm-13' }}
         run: |
           cd remill
           mkdir -p build && cd build

--- a/.github/workflows/vcpkg_ci_windows.yml
+++ b/.github/workflows/vcpkg_ci_windows.yml
@@ -151,7 +151,7 @@ jobs:
           # python ../scripts/roundtrip.py ( Get-ChildItem tools | Where-Object {$_.name -match "rellic-decomp.exe"} ) ..\tests\tools\decomp "${env:VCPKG_ROOT}\installed\${env:TRIPLET}\tools\${{ matrix.llvm }}\clang.exe"
 
       - name: 'Test remill build'
-        if: ${{ matrix.llvm == 'llvm-13' }}
+        # if: ${{ matrix.llvm == 'llvm-13' }}
         run: |
           cd remill
           Remove-Item -Recurse -Force -ErrorAction SilentlyContinue .\build

--- a/ports/z3/portfile.cmake
+++ b/ports/z3/portfile.cmake
@@ -1,6 +1,6 @@
-vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_DIR "${PYTHON2}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON2_DIR}")
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
+vcpkg_add_to_path("${PYTHON3_DIR}")
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/z3/vcpkg.json
+++ b/ports/z3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "z3",
   "version": "4.8.15",
+  "port-version": 1,
   "description": "Z3 is a theorem prover from Microsoft Research",
   "homepage": "https://github.com/Z3Prover/z3",
   "license": "MIT",


### PR DESCRIPTION
Python2 is EOL and the Z3 scripts work with both Python2 and Python3, so
we prefer Python3