### PR TITLE
pushed image should use arch_docker instead of arch

### DIFF
--- a/.github/workflows/vcpkg_docker_arm64.yml
+++ b/.github/workflows/vcpkg_docker_arm64.yml
@@ -84,14 +84,14 @@ jobs:
           fi
 
           # NOTE: Docker Hub only allows one slash in tag
-          docker build -f Dockerfile.ubuntu.vcpkg --target base --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" -t "trailofbits/cxx-common-vcpkg-builder-${{ matrix.container.distro }}:${{ matrix.container.version }}${{ matrix.host.arch }}" .
+          docker build -f Dockerfile.ubuntu.vcpkg --target base --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" -t "trailofbits/cxx-common-vcpkg-builder-${{ matrix.container.distro }}:${{ matrix.container.version }}${{ matrix.host.arch_docker }}" .
           # Smaller Docker image without NuGet support goes to Docker Hub for users
           if [[ "${GITHUB_REF}" == "refs/heads/master" ]] ; then
             docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_TOKEN}"
             for i in 1 2 3; do docker push "trailofbits/cxx-common-vcpkg-builder-${{ matrix.container.distro }}:${{ matrix.container.version }}${{ matrix.host.arch }}" && break || sleep 10; done
           fi
         env:
-          DOCKER_TAG: lifting-bits/cxx-common/vcpkg-builder-${{ matrix.container.distro }}:${{ matrix.container.version }}${{ matrix.host.arch }}
+          DOCKER_TAG: lifting-bits/cxx-common/vcpkg-builder-${{ matrix.container.distro }}:${{ matrix.container.version }}${{ matrix.host.arch_docker }}
           GITHUB_PACKAGE_REGISTRY_TOKEN: ${{  secrets.GITHUB_PACKAGE_REGISTRY_TOKEN  }}
           DOCKER_HUB_USER: ${{  secrets.DOCKER_HUB_USER  }}
           DOCKER_HUB_TOKEN: ${{  secrets.DOCKER_HUB_TOKEN  }}


### PR DESCRIPTION
https://github.com/lifting-bits/cxx-common/blob/master/.github/workflows/vcpkg_ci_aws_arm64.yml#L74
referenced image expects arch_docker instead of arch