### PR TITLE
Update gha

### DIFF
--- a/.github/workflows/vcpkg_ci_amd64.yml
+++ b/.github/workflows/vcpkg_ci_amd64.yml
@@ -140,7 +140,7 @@ jobs:
           echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
           echo "CMAKE_C_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
           echo "CMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
-          echo ::set-output name=timestamp::$(date +"%Y-%m-%d-%H:%M:%S" --utc)
+          echo "timestamp=$(date +"%Y-%m-%d-%H:%M:%S" --utc)" >> ${GITHUB_OUTPUT}
 
       - name: ccache cache files
         uses: actions/cache@v3

--- a/.github/workflows/vcpkg_ci_mac.yml
+++ b/.github/workflows/vcpkg_ci_mac.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os.runner }}
 
     env:
-      ARTIFACT_NAME: vcpkg_${{ matrix.os.runner }}_${{ matrix.llvm }}_xcode-${{ matrix.os.xcode }}_${{ matrix.target_arch }}
+      ARTIFACT_NAME: vcpkg_${{ matrix.os.runner }}_${{ matrix.llvm }}_xcode-${{ matrix.os.xcode }}_${{ matrix.target_arch == 'x64' && 'amd64' || matrix.target_arch }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/vcpkg_ci_mac.yml
+++ b/.github/workflows/vcpkg_ci_mac.yml
@@ -137,7 +137,7 @@ jobs:
           echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
           echo "CMAKE_C_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
           echo "CMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
-          echo ::set-output name=timestamp::$(python -c 'from datetime import datetime; print(datetime.utcnow().strftime("%Y-%m-%d-%H:%M:%S"))')
+          echo "timestamp=$(python -c 'from datetime import datetime; print(datetime.utcnow().strftime("%Y-%m-%d-%H:%M:%S"))')" >> ${GITHUB_OUTPUT}
 
       - name: ccache cache files
         uses: actions/cache@v3

--- a/.github/workflows/vcpkg_ci_windows.yml
+++ b/.github/workflows/vcpkg_ci_windows.yml
@@ -72,8 +72,8 @@ jobs:
         shell: bash
         run: |
           { read -r vcpkg_repo_url && read -r vcpkg_commit; } < ./vcpkg_info.txt || exit 1
-          echo ::set-output name=repo_url::${vcpkg_repo_url}
-          echo ::set-output name=commit::${vcpkg_commit}
+          echo "repo_url=${vcpkg_repo_url}" >> ${GITHUB_OUTPUT}
+          echo "commit=${vcpkg_commit}" >> ${GITHUB_OUTPUT}
 
         # Setup Visual Studio Dev Environment (x64, default version/toolset)
       - uses: ilammy/msvc-dev-cmd@v1.12.0


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Fixes these deprecations

Also normalize target_arch to match previous artifact output of amd64 instead of x64