### PR TITLE
Add fts5 module to sqlite3

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -14,4 +14,4 @@ re2
 zstd
 lz4
 doctest
-sqlite3
+sqlite3[fts5]


### PR DESCRIPTION
Adds fulltext text indexing support to SQLite3. The fts5 module is the latest version for fulltext searching.