### PR TITLE
Docker image v2

### DIFF
--- a/.github/workflows/vcpkg_docker_amd64.yml
+++ b/.github/workflows/vcpkg_docker_amd64.yml
@@ -69,13 +69,13 @@ jobs:
           for i in 1 2 3; do docker push "${DOCKER_TAG}" && break || sleep 10; done
 
           # NOTE: Docker Hub only allows one slash in tag
-          # DOCKER_TAG="trailofbits/cxx-common-${IMAGE_NAME}"
-          # docker build -f Dockerfile.ubuntu.vcpkg --target base --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" -t "${DOCKER_TAG}" .
+          DOCKER_TAG="trailofbits/cxx-common-${IMAGE_NAME}"
+          docker build -f Dockerfile.ubuntu.vcpkg --target base --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" -t "${DOCKER_TAG}" .
           # Smaller Docker image without NuGet support goes to Docker Hub for users
-          #if [[ "${GITHUB_REF}" == "refs/heads/master" ]] ; then
-          #  docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_TOKEN}"
-          #  for i in 1 2 3; do docker push "${DOCKER_TAG}" && break || sleep 10; done
-          #fi
+          if [[ "${GITHUB_REF}" == "refs/heads/master" ]] ; then
+            docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_TOKEN}"
+            for i in 1 2 3; do docker push "${DOCKER_TAG}" && break || sleep 10; done
+          fi
         env:
           GITHUB_PACKAGE_REGISTRY_TOKEN: ${{  secrets.GITHUB_PACKAGE_REGISTRY_TOKEN  }}
           # DOCKER_HUB_USER: ${{  secrets.DOCKER_HUB_USER  }}

--- a/.github/workflows/vcpkg_docker_amd64.yml
+++ b/.github/workflows/vcpkg_docker_amd64.yml
@@ -78,5 +78,5 @@ jobs:
           fi
         env:
           GITHUB_PACKAGE_REGISTRY_TOKEN: ${{  secrets.GITHUB_PACKAGE_REGISTRY_TOKEN  }}
-          # DOCKER_HUB_USER: ${{  secrets.DOCKER_HUB_USER  }}
-          # DOCKER_HUB_TOKEN: ${{  secrets.DOCKER_HUB_TOKEN  }}
+          DOCKER_HUB_USER: ${{  secrets.DOCKER_HUB_USER  }}
+          DOCKER_HUB_TOKEN: ${{  secrets.DOCKER_HUB_TOKEN  }}

--- a/.github/workflows/vcpkg_docker_amd64.yml
+++ b/.github/workflows/vcpkg_docker_amd64.yml
@@ -1,6 +1,7 @@
 name: Docker Build Images (AMD64)
 
 env:
+  # Also remember to change the 'docker/build.sh' script
   IMAGE_VER: "v2"
 
 on:
@@ -49,7 +50,7 @@ jobs:
           if [[ "${GITHUB_REF}" != "refs/heads/master" ]] ; then
             test_name="test-${BRANCH_NAME////_}-"
           fi
-          echo "IMAGE_NAME=${test_name}vcpkg-builder-ubuntu-${{ env.IMAGE_VER }}:${{ matrix.container.version }}${{ matrix.host.arch }}" >> ${GITHUB_ENV}
+          echo "IMAGE_NAME=ghcr.io/lifting-bits/cxx-common/${test_name}vcpkg-builder-ubuntu-${{ env.IMAGE_VER }}:${{ matrix.container.version }}${{ matrix.host.arch }}" >> ${GITHUB_ENV}
 
       - name: Build and Push
         working-directory: docker
@@ -57,26 +58,23 @@ jobs:
           # Pull freshest ubuntu Docker image
           docker pull ubuntu:${{ matrix.container.version}}
 
-          # Build for GitHub Actions registry
-          # Docker image with NuGet support goes to github packages for CI use only
-          DOCKER_TAG="docker.pkg.github.com/lifting-bits/cxx-common/${IMAGE_NAME}"
           docker build -f Dockerfile.ubuntu.vcpkg --no-cache \
               --target caching \
               --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" \
-              -t "${DOCKER_TAG}" \
+              -t "${IMAGE_NAME}" \
               .
           docker login docker.pkg.github.com -u publisher -p "${GITHUB_PACKAGE_REGISTRY_TOKEN}"
-          for i in 1 2 3; do docker push "${DOCKER_TAG}" && break || sleep 10; done
+          for i in 1 2 3; do docker push "${IMAGE_NAME}" && break || sleep 10; done
 
-          # NOTE: Docker Hub only allows one slash in tag
-          DOCKER_TAG="trailofbits/cxx-common-${IMAGE_NAME}"
-          docker build -f Dockerfile.ubuntu.vcpkg --target base --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" -t "${DOCKER_TAG}" .
-          # Smaller Docker image without NuGet support goes to Docker Hub for users
+          docker build -f Dockerfile.ubuntu.vcpkg \
+              --target base \
+              --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" \
+              -t "${IMAGE_NAME}" \
+              .
+          # Only push smaller image on default branch. This could change in the
+          # future if we actually need to test the smaller image before merging
           if [[ "${GITHUB_REF}" == "refs/heads/master" ]] ; then
-            docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_TOKEN}"
-            for i in 1 2 3; do docker push "${DOCKER_TAG}" && break || sleep 10; done
+            for i in 1 2 3; do docker push "${IMAGE_NAME}" && break || sleep 10; done
           fi
         env:
           GITHUB_PACKAGE_REGISTRY_TOKEN: ${{  secrets.GITHUB_PACKAGE_REGISTRY_TOKEN  }}
-          DOCKER_HUB_USER: ${{  secrets.DOCKER_HUB_USER  }}
-          DOCKER_HUB_TOKEN: ${{  secrets.DOCKER_HUB_TOKEN  }}

--- a/.github/workflows/vcpkg_docker_amd64.yml
+++ b/.github/workflows/vcpkg_docker_amd64.yml
@@ -1,5 +1,8 @@
 name: Docker Build Images (AMD64)
 
+env:
+  IMAGE_VER: "v2"
+
 on:
   schedule:
     # Once every Wednesday at 00:00
@@ -28,8 +31,8 @@ jobs:
         host:
           - { name: 'ubuntu-20.04', arch: '' }
         container:
-          - { distro: 'ubuntu', version: '20.04', codename: 'focal' }
-          - { distro: 'ubuntu', version: '22.04', codename: 'jammy' }
+          - { version: '20.04', codename: 'focal' }
+          - { version: '22.04', codename: 'jammy' }
 
     runs-on: ${{ matrix.host.name }}
 
@@ -52,14 +55,14 @@ jobs:
           fi
 
           # NOTE: Docker Hub only allows one slash in tag
-          docker build -f Dockerfile.ubuntu.vcpkg --target base --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" -t "trailofbits/cxx-common-vcpkg-builder-${{ matrix.container.distro }}:${{ matrix.container.version }}${{ matrix.host.arch }}" .
+          docker build -f Dockerfile.ubuntu.vcpkg --target base --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" -t "trailofbits/cxx-common-vcpkg-builder-ubuntu-${{ env.IMAGE_VER }}:${{ matrix.container.version }}${{ matrix.host.arch }}" .
           # Smaller Docker image without NuGet support goes to Docker Hub for users
           if [[ "${GITHUB_REF}" == "refs/heads/master" ]] ; then
             docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_TOKEN}"
-            for i in 1 2 3; do docker push "trailofbits/cxx-common-vcpkg-builder-${{ matrix.container.distro }}:${{ matrix.container.version }}${{ matrix.host.arch }}" && break || sleep 10; done
+            for i in 1 2 3; do docker push "trailofbits/cxx-common-vcpkg-builder-ubuntu-${{ env.IMAGE_VER }}:${{ matrix.container.version }}${{ matrix.host.arch }}" && break || sleep 10; done
           fi
         env:
-          DOCKER_TAG: lifting-bits/cxx-common/vcpkg-builder-${{ matrix.container.distro }}:${{ matrix.container.version }}${{ matrix.host.arch }}
+          DOCKER_TAG: lifting-bits/cxx-common/vcpkg-builder-ubuntu-${{ env.IMAGE_VER }}:${{ matrix.container.version }}${{ matrix.host.arch }}
           GITHUB_PACKAGE_REGISTRY_TOKEN: ${{  secrets.GITHUB_PACKAGE_REGISTRY_TOKEN  }}
           DOCKER_HUB_USER: ${{  secrets.DOCKER_HUB_USER  }}
           DOCKER_HUB_TOKEN: ${{  secrets.DOCKER_HUB_TOKEN  }}

--- a/.github/workflows/vcpkg_docker_amd64.yml
+++ b/.github/workflows/vcpkg_docker_amd64.yml
@@ -56,30 +56,33 @@ jobs:
           fi
           echo "IMAGE_NAME=ghcr.io/lifting-bits/cxx-common/${test_name}vcpkg-builder-ubuntu-${{ env.IMAGE_VER }}:${{ matrix.container.version }}${{ matrix.host.arch }}" >> ${GITHUB_ENV}
 
-      - name: Build and Push
+      - name: Build caching image
         working-directory: docker
         run: |
           # Pull freshest ubuntu Docker image
           docker pull ubuntu:${{ matrix.container.version}}
 
-          docker build -f Dockerfile.ubuntu.vcpkg --no-cache \
+          docker build -f Dockerfile.ubuntu.vcpkg \
+              --no-cache \
               --target caching \
               --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" \
               -t "${IMAGE_NAME}" \
               .
 
-          # Authenticate with container registry
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
-          for i in 1 2 3; do docker push "${IMAGE_NAME}" && break || sleep 10; done
+      - name: Push caching image
+        run: docker push "${IMAGE_NAME}"
 
+      - name: Build and Push non-caching image
+        if: github.ref == 'refs/heads/master'
+        run: |
+          # Only push smaller image on default branch. This could change in the
+          # future if we actually need to test the smaller image before merging
           docker build -f Dockerfile.ubuntu.vcpkg \
               --target base \
               --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" \
               -t "${IMAGE_NAME}" \
               .
-          # Only push smaller image on default branch. This could change in the
-          # future if we actually need to test the smaller image before merging
-          if [[ "${GITHUB_REF}" == "refs/heads/master" ]] ; then
-            for i in 1 2 3; do docker push "${IMAGE_NAME}" && break || sleep 10; done
-          fi
+          docker push "${IMAGE_NAME}"

--- a/.github/workflows/vcpkg_docker_amd64.yml
+++ b/.github/workflows/vcpkg_docker_amd64.yml
@@ -37,6 +37,10 @@ jobs:
 
     runs-on: ${{ matrix.host.name }}
 
+    permissions:
+      packages: write
+      contents: read
+
     steps:
       - name: Cleanup working directory with container root
         run: |

--- a/.github/workflows/vcpkg_docker_amd64.yml
+++ b/.github/workflows/vcpkg_docker_amd64.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         # arch is to tag docker images for uniqueness
         host:
-          - { name: 'ubuntu-20.04', arch: '' }
+          - { name: 'ubuntu-22.04', arch: '' }
         container:
           - { version: '20.04', codename: 'focal' }
           - { version: '22.04', codename: 'jammy' }
@@ -41,28 +41,42 @@ jobs:
         run: |
           docker run --rm -v $(pwd):/workspace -w /workspace ubuntu:latest find . -name . -o -prune -exec rm -rf -- {} + || true
       - uses: actions/checkout@v3
+      - name: Generate Image Name
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          test_name=""
+          if [[ "${GITHUB_REF}" != "refs/heads/master" ]] ; then
+            test_name="test-${BRANCH_NAME////_}-"
+          fi
+          echo "IMAGE_NAME=${test_name}vcpkg-builder-ubuntu-${{ env.IMAGE_VER }}:${{ matrix.container.version }}${{ matrix.host.arch }}" >> ${GITHUB_ENV}
+
       - name: Build and Push
         working-directory: docker
         run: |
           # Pull freshest ubuntu Docker image
           docker pull ubuntu:${{ matrix.container.version}}
 
-          docker build -f Dockerfile.ubuntu.vcpkg --target caching --no-cache --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" -t "docker.pkg.github.com/${DOCKER_TAG}" .
+          # Build for GitHub Actions registry
           # Docker image with NuGet support goes to github packages for CI use only
-          if [[ "${GITHUB_REF}" == "refs/heads/master" ]] ; then
-            docker login docker.pkg.github.com -u publisher -p "${GITHUB_PACKAGE_REGISTRY_TOKEN}"
-            for i in 1 2 3; do docker push "docker.pkg.github.com/${DOCKER_TAG}" && break || sleep 10; done
-          fi
+          DOCKER_TAG="docker.pkg.github.com/lifting-bits/cxx-common/${IMAGE_NAME}"
+          docker build -f Dockerfile.ubuntu.vcpkg --no-cache \
+              --target caching \
+              --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" \
+              -t "${DOCKER_TAG}" \
+              .
+          docker login docker.pkg.github.com -u publisher -p "${GITHUB_PACKAGE_REGISTRY_TOKEN}"
+          for i in 1 2 3; do docker push "${DOCKER_TAG}" && break || sleep 10; done
 
           # NOTE: Docker Hub only allows one slash in tag
-          docker build -f Dockerfile.ubuntu.vcpkg --target base --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" -t "trailofbits/cxx-common-vcpkg-builder-ubuntu-${{ env.IMAGE_VER }}:${{ matrix.container.version }}${{ matrix.host.arch }}" .
+          # DOCKER_TAG="trailofbits/cxx-common-${IMAGE_NAME}"
+          # docker build -f Dockerfile.ubuntu.vcpkg --target base --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" -t "${DOCKER_TAG}" .
           # Smaller Docker image without NuGet support goes to Docker Hub for users
-          if [[ "${GITHUB_REF}" == "refs/heads/master" ]] ; then
-            docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_TOKEN}"
-            for i in 1 2 3; do docker push "trailofbits/cxx-common-vcpkg-builder-ubuntu-${{ env.IMAGE_VER }}:${{ matrix.container.version }}${{ matrix.host.arch }}" && break || sleep 10; done
-          fi
+          #if [[ "${GITHUB_REF}" == "refs/heads/master" ]] ; then
+          #  docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_TOKEN}"
+          #  for i in 1 2 3; do docker push "${DOCKER_TAG}" && break || sleep 10; done
+          #fi
         env:
-          DOCKER_TAG: lifting-bits/cxx-common/vcpkg-builder-ubuntu-${{ env.IMAGE_VER }}:${{ matrix.container.version }}${{ matrix.host.arch }}
           GITHUB_PACKAGE_REGISTRY_TOKEN: ${{  secrets.GITHUB_PACKAGE_REGISTRY_TOKEN  }}
-          DOCKER_HUB_USER: ${{  secrets.DOCKER_HUB_USER  }}
-          DOCKER_HUB_TOKEN: ${{  secrets.DOCKER_HUB_TOKEN  }}
+          # DOCKER_HUB_USER: ${{  secrets.DOCKER_HUB_USER  }}
+          # DOCKER_HUB_TOKEN: ${{  secrets.DOCKER_HUB_TOKEN  }}

--- a/.github/workflows/vcpkg_docker_amd64.yml
+++ b/.github/workflows/vcpkg_docker_amd64.yml
@@ -63,7 +63,10 @@ jobs:
               --build-arg "DISTRO_VERSION=${{ matrix.container.codename }}" \
               -t "${IMAGE_NAME}" \
               .
-          docker login docker.pkg.github.com -u publisher -p "${GITHUB_PACKAGE_REGISTRY_TOKEN}"
+
+          # Authenticate with container registry
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
           for i in 1 2 3; do docker push "${IMAGE_NAME}" && break || sleep 10; done
 
           docker build -f Dockerfile.ubuntu.vcpkg \
@@ -76,5 +79,3 @@ jobs:
           if [[ "${GITHUB_REF}" == "refs/heads/master" ]] ; then
             for i in 1 2 3; do docker push "${IMAGE_NAME}" && break || sleep 10; done
           fi
-        env:
-          GITHUB_PACKAGE_REGISTRY_TOKEN: ${{  secrets.GITHUB_PACKAGE_REGISTRY_TOKEN  }}

--- a/.github/workflows/vcpkg_docker_amd64.yml
+++ b/.github/workflows/vcpkg_docker_amd64.yml
@@ -70,7 +70,7 @@ jobs:
               .
 
       - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push caching image
         run: docker push "${IMAGE_NAME}"

--- a/docker/Dockerfile.ubuntu.vcpkg
+++ b/docker/Dockerfile.ubuntu.vcpkg
@@ -1,5 +1,5 @@
 ARG DISTRO_VERSION=focal
-ARG LLVM_VERSION=14
+ARG LLVM_VERSION=16
 
 ARG BUILD_BASE=ubuntu:${DISTRO_VERSION}
 FROM ${BUILD_BASE} as base
@@ -17,16 +17,20 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-add-repository ppa:git-core/ppa --yes && \
     wget "https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-$(uname -m).sh" && \
     /bin/bash cmake-*.sh --skip-license --prefix=/usr/local && rm cmake-*.sh && \
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb http://apt.llvm.org/${DISTRO_VERSION}/ llvm-toolchain-${DISTRO_VERSION}-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
-    echo "deb-src http://apt.llvm.org/${DISTRO_VERSION}/ llvm-toolchain-${DISTRO_VERSION}-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
+    \
+    wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    ./llvm.sh ${LLVM_VERSION} clang lld && \
+    \
     apt-get update && apt-get upgrade --yes && \
     apt-get install --yes --no-install-recommends \
-      "$( [ "$(uname -m)" != "aarch64" ] && echo "g++-multilib")" \
-      "$( [ "$(uname -m)" = "aarch64" ] && echo "libstdc++-*-dev:armhf")" \
       libtinfo-dev libzstd-dev python3-pip python3-setuptools python-setuptools \
-      build-essential g++ gcc clang lld clang-${LLVM_VERSION} lld-${LLVM_VERSION} ninja-build \
+      build-essential binutils-multiarch g++ gcc clang lld clang-${LLVM_VERSION} lld-${LLVM_VERSION} ninja-build \
       pixz xz-utils make rpm curl unzip tar git zip python3 pkg-config && \
+      apt-get install --yes --no-install-recommends \
+      $( [ "$(uname -m)" = "x86_64" ] && echo crossbuild-essential-i386 crossbuild-essential-arm64 linux-libc-dev-amd64-cross) \
+      "$( [ "$(uname -m)" = "aarch64" ] && echo "libstdc++-$(gcc -dumpversion | cut -f1 -d.)-dev:armhf")" && \
+    \
     apt-get clean --yes && \
     rm -rf /var/lib/apt/lists/* && \
     \
@@ -36,11 +40,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     cmake -S . -B build -G Ninja -DREDIS_STORAGE_BACKEND=OFF -DCMAKE_BUILD_TYPE=Release && \
     cmake --build build --target install && \
     cd .. && rm -rf ccache-ccache-*
-
-# Default to system clang because things will break if mixing objects compiled with system clang and clang-14
-ENV CC=/usr/bin/clang \
-    CXX=/usr/bin/clang++
-
 
 # Much heavier installation due to mono dependency for NuGet
 FROM base as caching

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # Builds base images with all required dependencies to bootstrap vcpkg and
 # build vcpkg libraries as well as all lifting-bits tools
 
+# Also remember to change the '.github/workflows/vcpkg_docker_amd64.yml' variable
+IMAGE_VER=v2
+
 # Ubuntu versions to build
 UBUNTU_VERSION_MATRIX=( "focal" "jammy" )
 
@@ -13,7 +16,7 @@ for version in "${UBUNTU_VERSION_MATRIX[@]}"; do
   docker pull "ubuntu:${version}"
 
   # Image identification
-  tag="vcpkg-builder-ubuntu-v2:${version}"
+  tag="vcpkg-builder-ubuntu-${IMAGE_VER}:${version}"
 
   # Build
   docker build \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -13,7 +13,7 @@ for version in "${UBUNTU_VERSION_MATRIX[@]}"; do
   docker pull "ubuntu:${version}"
 
   # Image identification
-  tag="vcpkg-builder-ubuntu:${version}"
+  tag="vcpkg-builder-ubuntu-v2:${version}"
 
   # Build
   docker build \


### PR DESCRIPTION
~DO NOT MERGE UNTIL #1018 passes~


New naming scheme appends `-v#` to the image name. The tag part is not changed

Removed Docker Hub pushes. Now we use ghcr.io for both images.

Use GCC for cross-compilation on Linux because Ubuntu and vcpkg have better support for cross-compilation when using GCC