### PR TITLE
Add llvm-16 patch to not crash on invalid sourcelocs

### DIFF
--- a/ports/llvm-16/0029-Do-not-attempt-macro-expansion-on-invalid-sourceloc.patch
+++ b/ports/llvm-16/0029-Do-not-attempt-macro-expansion-on-invalid-sourceloc.patch
@@ -1,0 +1,28 @@
+From efcdeb698fe6a475d1eb0a8f4770ef974cefb0e1 Mon Sep 17 00:00:00 2001
+From: 2over12 <ian.smith@trailofbits.com>
+Date: Wed, 31 May 2023 08:57:45 -0400
+Subject: [PATCH] Do not attempt to find macro expansions if there is invalid
+ source info for a decl
+
+---
+ clang/lib/AST/Expr.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/clang/lib/AST/Expr.cpp b/clang/lib/AST/Expr.cpp
+index e45ae68cd5fe..59a7d50d8ad3 100644
+--- a/clang/lib/AST/Expr.cpp
++++ b/clang/lib/AST/Expr.cpp
+@@ -263,6 +263,10 @@ bool Expr::isFlexibleArrayMemberLike(
+       TypeSourceInfo *TInfo = FD->getTypeSourceInfo();
+       while (TInfo) {
+         TypeLoc TL = TInfo->getTypeLoc();
++        if (TL.getSourceRange().isInvalid()) {
++          break;
++        }
++        
+         // Look through typedefs.
+         if (TypedefTypeLoc TTL = TL.getAsAdjusted<TypedefTypeLoc>()) {
+           const TypedefNameDecl *TDL = TTL.getTypedefNameDecl();
+-- 
+2.39.2 (Apple Git-143)
+

--- a/ports/llvm-16/portfile.cmake
+++ b/ports/llvm-16/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         0020-fix-FindZ3.cmake.patch
         0021-fix-find_dependency.patch
         0026-fix-prefix-path-calc.patch
+        0029-Do-not-attempt-macro-expansion-on-invalid-sourceloc.patch
 )
 
 if("pasta" IN_LIST FEATURES)


### PR DESCRIPTION
Clang 16 added a semantic check for flexible array members that relies on grabbing sourceloc info for array types that are the last member of a union. If the sourceloc info is empty `dyn_cast<IntegerLiteral>(CTL.getSizeExpr())` will crash because getSizeExpr will be null and dyn_cast asserts a nonnulll input. Another plausible fix would be to do dyn_cast_or_null here but that would result in false. Still determining the best patch/testing 