### PR TITLE
Improve port upgrading experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ See [the vcpkg docs](https://github.com/microsoft/vcpkg/blob/master/docs/example
 
 Installing additional dependencies will not update any existing dependencies by default. We do not update/upgrade by default because this could cause unexpected rebuilds that could potentially take hours (in the case of LLVM). To update dependencies, pass the `--upgrade-ports` option to the build script along with the respective options affecting vcpkg triplet selection (like `--release`).
 
+You must specify the exact package/ports you want to upgrade. If the port does not exist, this will fail.
+
 ## Useful manual vcpkg commands
 
 Sometimes it is useful to run vcpkg commands manually for testing a single package. Ideally, someone who wants to do this would read the [vcpkg documentation](https://github.com/microsoft/vcpkg/tree/master/docs), but below we list some commonly used commands. Inspecting the output of the build script will also show all of the vcpkg commands executed.

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -82,7 +82,7 @@ while [[ $# -gt 0 ]] ; do
   esac
   shift
 done
-msg "Passing extra args to 'vcpkg install':"
+msg "Passing extra args to vcpkg:"
 msg " " "${VCPKG_ARGS[@]}"
 
 function die_if_not_installed {
@@ -237,10 +237,19 @@ if [[ ${UPGRADE_PORTS} == "true" ]]; then
     cd "${repo_dir}"
     (
       set -x
-      # shellcheck disable=SC2046
-      "${vcpkg_dir}/vcpkg" upgrade "${extra_vcpkg_args[@]}" "${overlays[@]}" --no-dry-run --allow-unsupported
+      "${vcpkg_dir}/vcpkg" upgrade "${extra_vcpkg_args[@]}" "${overlays[@]}" --allow-unsupported "${VCPKG_ARGS[@]}" || true
+
+      set +x
+      read -p "Are you sure? If so, enter 'y' " -n 1 -r
+      echo ""
+      if [[ $REPLY =~ ^[Yy]$ ]]
+      then
+        set -x
+        "${vcpkg_dir}/vcpkg" upgrade "${extra_vcpkg_args[@]}" "${overlays[@]}" --no-dry-run --allow-unsupported "${VCPKG_ARGS[@]}" || exit 1
+      fi
     )
-  ) || exit 1
+  )
+  exit 0
 fi
 
 deps=()


### PR DESCRIPTION
Only upgrade ports that are specified. Also ask the user if they're sure they want to upgrade.

Should prevent accidentally deleting/rebuilding LLVM if it's out of date or if trying to upgrade a port it depends on.